### PR TITLE
FAQ.md under ui-test-example, Interceptor to debug the retrofit calls…

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/remote-robot/build.gradle.kts
+++ b/remote-robot/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.bouncycastle:bcprov-jdk15on:1.66")
 
+    //Logging Network Calls
+    implementation("com.squareup.okhttp3:logging-interceptor:4.2.1")
+
     api("org.assertj:assertj-swing-junit:3.9.2")
     api("org.apache.logging.log4j:log4j-api:2.11.1")
     api("org.apache.logging.log4j:log4j-core:2.11.1")

--- a/robot-server-plugin/build.gradle.kts
+++ b/robot-server-plugin/build.gradle.kts
@@ -33,9 +33,9 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.2.3")
     implementation("org.assertj:assertj-swing-junit:3.9.2")
 
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.2.0")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.2.0")
-    testRuntime("org.junit.platform:junit-platform-launcher:1.2.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.2.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.2.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.2.0")
 
     implementation("org.mozilla:rhino:1.7.12")
 }

--- a/ui-test-example/FAQ.md
+++ b/ui-test-example/FAQ.md
@@ -1,0 +1,5 @@
+#### Why on my mac the UI click are not working
+
+On mac computers, you will need to allow the IDE to control their computer:
+```Security & Privacy``` -> ```Accessibility``` -> ```Allow the apps below to control your computer``` and select the
+IDE you are working with

--- a/ui-test-example/build.gradle
+++ b/ui-test-example/build.gradle
@@ -44,6 +44,10 @@ intellij {
 runIdeForUiTests {
     systemProperty "robot-server.port", "8082"
     systemProperty "ide.mac.message.dialogs.as.sheets", "false"
+
+    // enable to log the retrofit call
+    // systemProperty "debug-retrofit", "enable"
+
 }
 
 test {

--- a/ui-test-example/build.gradle
+++ b/ui-test-example/build.gradle
@@ -45,11 +45,13 @@ runIdeForUiTests {
     systemProperty "robot-server.port", "8082"
     systemProperty "ide.mac.message.dialogs.as.sheets", "false"
 
-    // enable to log the retrofit call
+    // enable here and in test block - to log the retrofit HTTP calls
     // systemProperty "debug-retrofit", "enable"
 
 }
 
 test {
+    // enable here nad in runIdeForUiTests block - to log the retrofit HTTP calls
+    // systemProperty "debug-retrofit", "enable"
     useJUnitPlatform()
 }

--- a/ui-test-example/build.gradle
+++ b/ui-test-example/build.gradle
@@ -45,9 +45,6 @@ runIdeForUiTests {
     systemProperty "robot-server.port", "8082"
     systemProperty "ide.mac.message.dialogs.as.sheets", "false"
 
-    // enable here and in test block - to log the retrofit HTTP calls
-    // systemProperty "debug-retrofit", "enable"
-
 }
 
 test {


### PR DESCRIPTION
Copy-Paste from the closed issue - https://github.com/JetBrains/intellij-ui-test-robot/issues/3#issue-771605310
I am having some issues defining the debug retrofit with a system property.

I added to the RemoteRobot the following:

    val okHttpClient: OkHttpClient = if (System.getProperty("debug-retrofit")?.equals("enable") ?: false) {
        val interceptor: HttpLoggingInterceptor = HttpLoggingInterceptor().apply {
            this.level = HttpLoggingInterceptor.Level.BODY
        }
        OkHttpClient.Builder().apply {
            this.addInterceptor(interceptor)
        }.build()
    } else {
        DefaultHttpClient.client
    }
and in the runIdeForUiTests in the example project:

```
systemProperty "debug-retrofit", "enable"
```
But the RemoteRobot does not get that. 
If I am forcing it to use the interceptor with

```
if (true)
```

It does work.

My guess is that there are 2 processes and the RemoteRobot class is not invoked as part of the
runIdeForUiTests but on the other process.

Any suggestions about it?
I'll open a PR and let me know what you think, I can leave it as a comment or remove it completely if we don't find a solution.

Thanks