### PR TITLE
Expose the browser HTML to the client

### DIFF
--- a/remote-robot/src/main/kotlin/com/intellij/remoterobot/client/IdeRobotApi.kt
+++ b/remote-robot/src/main/kotlin/com/intellij/remoterobot/client/IdeRobotApi.kt
@@ -4,12 +4,18 @@ package com.intellij.remoterobot.client
 
 import com.intellij.remoterobot.data.ObjectContainer
 import com.intellij.remoterobot.data.js.ExecuteScriptRequest
+import okhttp3.ResponseBody
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface IdeRobotApi {
+    @GET("/")
+    fun getHierarchy(): Call<ResponseBody>
+
     @POST("/component")
     fun findByLambda(@Body lambda: ObjectContainer): Call<FindComponentsResponse>
 

--- a/remote-robot/src/main/kotlin/com/intellij/remoterobot/client/IdeRobotClient.kt
+++ b/remote-robot/src/main/kotlin/com/intellij/remoterobot/client/IdeRobotClient.kt
@@ -11,6 +11,12 @@ import org.intellij.lang.annotations.Language
 import retrofit2.Response
 
 class IdeRobotClient(private val ideRobotApi: IdeRobotApi) {
+    fun getHierarchy(): String {
+        val response = ideRobotApi.getHierarchy().execute()
+        check(response.isSuccessful) { "request failed" }
+        return response.body()!!.string()
+    }
+
     fun findByLambda(lambda: ObjectContainer): RemoteComponent {
         return processFindResponse(ideRobotApi.findByLambda(lambda).execute()).single()
     }


### PR DESCRIPTION
Add an API to get the HTML view of the document view to help triage.

This can be combined with for example the following junit5 extension:
```
import org.junit.jupiter.api.extension.ExtensionContext
import org.junit.jupiter.api.extension.TestWatcher
import software.aws.toolkits.core.utils.writeText
import java.nio.file.Paths

class TestRecorder : TestWatcher {
    private companion object {
        val TEST_REPORTS_LOCATION by lazy {
            System.getProperty("testReportPath")?.let {
                Paths.get(it)
            }
        }
    }

    override fun testFailed(context: ExtensionContext, cause: Throwable) {
        val testReport = TEST_REPORTS_LOCATION?.resolve(context.displayName) ?: return

        uiTest {
            val hierarchyDump = ideRobotClient.getHierarchy()
            testReport.resolve("uiHierarchy.html").writeText(hierarchyDump)
        }
    }
}
```

Not perfect since the document can change between the failure and the retrieval but good place to start