### PR TITLE
allow to pass custom gson converter to RemoteRobot

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 rr_main_version=0.11
-rr_build=18
+rr_build=19

--- a/remote-robot/src/main/kotlin/com/intellij/remoterobot/RemoteRobot.kt
+++ b/remote-robot/src/main/kotlin/com/intellij/remoterobot/RemoteRobot.kt
@@ -32,11 +32,12 @@ annotation class RemoteCommand
 class RemoteRobot @JvmOverloads constructor(
     robotServerUrl: String,
     okHttpClient: OkHttpClient = DefaultHttpClient.client,
-    secret: String? = null
+    secret: String? = null,
+    gsonConverterFactory: GsonConverterFactory = GsonConverterFactory.create()
 ) : SearchContext, JavaScriptApi, LambdaApi {
     override val ideRobotClient = IdeRobotClient(
         Retrofit.Builder().baseUrl(robotServerUrl)
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(gsonConverterFactory)
             .client(okHttpClient)
             .build()
             .create(IdeRobotApi::class.java)


### PR DESCRIPTION
There is a [known issue of Gson](https://github.com/google/gson/issues/2352) with multi-module Java17 projects. For some cases we need to register a custom TypeAdapter:
```
Caused by: com.google.gson.JsonIOException: Failed making field 'java.lang.Throwable#detailMessage' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.
```