### PR TITLE
Add Rider to the list of IDEs

### DIFF
--- a/ide-launcher/src/main/kotlin/com/intellij/remoterobot/launcher/Ide.kt
+++ b/ide-launcher/src/main/kotlin/com/intellij/remoterobot/launcher/Ide.kt
@@ -7,7 +7,8 @@ enum class Ide(val code: String, val feedsCode: String) {
     WEBSTORM("WS", "WS"),
     RUBY_MINE("RM", "RM"),
     PYCHARM("PY", "PCP"),
-    PYCHARM_COMMUNITY("PC", "PCC");
+    PYCHARM_COMMUNITY("PC", "PCC"),
+    RIDER("RD", "RD");
 
     fun getIdePropertiesEnvVarName() = when (this) {
         IDEA_COMMUNITY, IDEA_ULTIMATE -> "IDEA_PROPERTIES"
@@ -15,6 +16,7 @@ enum class Ide(val code: String, val feedsCode: String) {
         WEBSTORM -> if (Os.hostOS() == Os.MAC) "WEBSTORM_PROPERTIES" else "WEBIDE_PROPERTIES"
         RUBY_MINE -> "RUBYMINE_PROPERTIES"
         PYCHARM, PYCHARM_COMMUNITY -> "PYCHARM_PROPERTIES"
+        RIDER -> "RIDER_PROPERTIES"
     }
 
     fun getVmOptionsEnvVarName() = when (this) {
@@ -23,6 +25,7 @@ enum class Ide(val code: String, val feedsCode: String) {
         WEBSTORM -> if (Os.hostOS() == Os.MAC) "WEBSTORM_VM_OPTIONS" else "WEBIDE_VM_OPTIONS"
         RUBY_MINE -> "RUBYMINE_VM_OPTIONS"
         PYCHARM, PYCHARM_COMMUNITY -> "PYCHARM_VM_OPTIONS"
+        RIDER -> "RIDER_VM_OPTIONS"
     }.let {
         if (Os.hostOS() == Os.WINDOWS) {
             val productPrefix = it.substringBefore("_")

--- a/ide-launcher/src/main/kotlin/com/intellij/remoterobot/launcher/IdeLauncher.kt
+++ b/ide-launcher/src/main/kotlin/com/intellij/remoterobot/launcher/IdeLauncher.kt
@@ -126,6 +126,7 @@ object IdeLauncher {
             Ide.WEBSTORM -> "webstorm"
             Ide.RUBY_MINE -> "rubymine"
             Ide.PYCHARM, Ide.PYCHARM_COMMUNITY -> "pycharm"
+            Ide.RIDER -> "rider"
         }
         val startupScriptPath = when (Os.hostOS()) {
             Os.LINUX -> "bin/${startupScriptName}.sh"


### PR DESCRIPTION
We started to develop E2E UI tests with Rider and would like to use IdeLauncher and manage it in the test runner, as we already have the prat of the framework to prepare the environment so we can use same agents as for other integration tests.
