### PR TITLE
Add override of getActionUpdateThread for OpenRecorderAction

### DIFF
--- a/test-recorder/src/main/kotlin/com/intellij/remoterobot/recorder/action/OpenRecorderAction.kt
+++ b/test-recorder/src/main/kotlin/com/intellij/remoterobot/recorder/action/OpenRecorderAction.kt
@@ -1,6 +1,7 @@
 // Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.remoterobot.recorder.action
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
@@ -13,6 +14,10 @@ internal class OpenRecorderAction : AnAction(), DumbAware {
 
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabled = RecorderService.getInstance().isOpened.not()
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.EDT
     }
 }
 


### PR DESCRIPTION
According to https://plugins.jetbrains.com/docs/intellij/working-with-custom-actions.html#creating-a-custom-action 
> When targeting IntelliJ Platform 2022.3 or later, AnAction.getActionUpdateThread() must be implemented

 I used EDT here because OpenRecorderAction is about UI recording. I've also checked locally two things: 
1. The action works after adding of override
2. The IDE error `ActionUpdateThread.OLD_EDT is deprecated` has disappeared 