### PR TITLE
RIDER-112162: Allow additional steps before launching IDE

### DIFF
--- a/ide-launcher/src/main/kotlin/com/intellij/remoterobot/launcher/IdeLauncher.kt
+++ b/ide-launcher/src/main/kotlin/com/intellij/remoterobot/launcher/IdeLauncher.kt
@@ -14,7 +14,8 @@ object IdeLauncher {
         additionalProperties: Map<String, Any>,
         additionalVmOptions: List<String>,
         requiredPluginsArchives: List<Path>,
-        ideSandboxDir: Path
+        ideSandboxDir: Path,
+        beforeLaunchAction: (Map<String, Any>) -> Unit = {}
     ): Process {
         val configDir = Files.createTempDirectory(ideSandboxDir, "config")
         val systemDir = Files.createTempDirectory(ideSandboxDir, "system")
@@ -32,6 +33,7 @@ object IdeLauncher {
             buildIdeProperties(pathToIde, configDir, systemDir, pluginsDir, logDir) + additionalProperties
         val vmOptions = readIdeDefaultVmOptions(pathToIde) + additionalVmOptions
 
+        beforeLaunchAction(ideProperties)
         return runIde(pathToIde, ideSandboxDir, ideProperties.mapValues { it.value.toString() }, vmOptions)
     }
 


### PR DESCRIPTION
We have a need to the initial Wizard setup and that requires no config directory to exist when IDE is started. Instead of adding an additional argument, I belive it's more scalable to allow a lambda which is executed just before the process start.

I'm not sure if it's fine to provide properties map, just to get e.g. plugins directory keys etc., as it also would be fine to just allow any lambda.

Please, let me know what you think.