### PR TITLE
add throwable type adapter

### DIFF
--- a/remote-robot/src/main/kotlin/com/intellij/remoterobot/RemoteRobot.kt
+++ b/remote-robot/src/main/kotlin/com/intellij/remoterobot/RemoteRobot.kt
@@ -2,6 +2,7 @@
 
 package com.intellij.remoterobot
 
+import com.google.gson.GsonBuilder
 import com.intellij.remoterobot.client.IdeRobotApi
 import com.intellij.remoterobot.client.IdeRobotClient
 import com.intellij.remoterobot.data.RemoteComponent
@@ -14,6 +15,7 @@ import com.intellij.remoterobot.fixtures.Fixture
 import com.intellij.remoterobot.search.Finder
 import com.intellij.remoterobot.search.locators.Locator
 import com.intellij.remoterobot.utils.DefaultHttpClient
+import com.intellij.remoterobot.utils.ThrowableTypeAdapter
 import com.intellij.remoterobot.utils.waitFor
 import okhttp3.OkHttpClient
 import org.intellij.lang.annotations.Language
@@ -28,15 +30,19 @@ import javax.imageio.ImageIO
 @DslMarker
 annotation class RemoteCommand
 
-
 class RemoteRobot @JvmOverloads constructor(
     robotServerUrl: String,
     okHttpClient: OkHttpClient = DefaultHttpClient.client,
     secret: String? = null
 ) : SearchContext, JavaScriptApi, LambdaApi {
+
+    private val gson = GsonBuilder()
+        .registerTypeAdapter(Throwable::class.java, ThrowableTypeAdapter)
+        .create()
+
     override val ideRobotClient = IdeRobotClient(
         Retrofit.Builder().baseUrl(robotServerUrl)
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create(gson))
             .client(okHttpClient)
             .build()
             .create(IdeRobotApi::class.java)

--- a/remote-robot/src/main/kotlin/com/intellij/remoterobot/utils/ThrowableTypeAdapter.kt
+++ b/remote-robot/src/main/kotlin/com/intellij/remoterobot/utils/ThrowableTypeAdapter.kt
@@ -1,0 +1,36 @@
+package com.intellij.remoterobot.utils
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+
+object ThrowableTypeAdapter : TypeAdapter<Throwable>() {
+
+    override fun write(writer: JsonWriter, value: Throwable?) {
+        if (value == null) {
+            writer.nullValue()
+            return
+        }
+        writer.beginObject()
+
+        // Include exception type name to give more context; for example, NullPointerException might
+        // not have a message
+        writer.name("type")
+        writer.value(value::class.java.getSimpleName())
+
+        writer.name("message")
+        writer.value(value.message)
+
+        val cause = value.cause
+        if (cause != null) {
+            writer.name("cause")
+            write(writer, cause)
+        }
+
+        writer.endObject()
+    }
+
+    override fun read(reader: JsonReader): Throwable {
+        throw UnsupportedOperationException()
+    }
+}


### PR DESCRIPTION
Hey!

When trying to run tests from an IDE using the JUnit runner in a hybrid Kotlin/Java project (for example, in case if a project uses [this](https://github.com/JetBrains/intellij-platform-plugin-template) template) I get errors like:

```
java.lang.IllegalArgumentException: Unable to create converter for class com.intellij.remoterobot.client.RetrieveResponse
    for method IdeRobotApi.screenshot

Caused by: com.google.gson.JsonIOException: Failed making field 'java.lang.Throwable#detailMessage' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.
```
This happens because of the difference between ```java.lang.Throwable``` and ```kotlin.Throwable``` which Robot framework is using in his API model, as the Java version of Throwable type also contains hidden members. Actually, Gson does not contain ThrowableTypeAdapter out of the box and does not know how to deserialize this type, as it was mention [here](https://github.com/google/gson/issues/2352).

So, adding a ThrowableTypeAdapter explicetly may solve this issue.
