### PR TITLE
Provide writeIntentLock for EDT operations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,22 @@
 plugins {
     id("org.jetbrains.kotlin.jvm") version "2.0.20"
-    id("org.jetbrains.intellij") version "1.17.3"
+    id("org.jetbrains.intellij.platform") version "2.3.0"
 }
 
 repositories {
     mavenCentral()
+
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
-intellij {
-    version.set("LATEST-EAP-SNAPSHOT")
+dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity("2024.1")
+    }
 }
+
 subprojects {
     apply {
         plugin(JavaPlugin::class.java)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 rr_main_version=0.11
-rr_build=23
+rr_build=24

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/remote-fixtures/build.gradle.kts
+++ b/remote-fixtures/build.gradle.kts
@@ -1,25 +1,28 @@
 plugins {
-    id("org.jetbrains.intellij")
+    id("org.jetbrains.intellij.platform")
     id("idea")
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.17.0"
 }
 
-intellij {
-    version.set("LATEST-EAP-SNAPSHOT")
+dependencies {
+    implementation(project(":remote-robot"))
+
+    intellijPlatform {
+        intellijIdeaCommunity("2024.1")
+    }
 }
 
 repositories {
     mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 idea {
     module {
         isDownloadSources = true
     }
-}
-
-dependencies {
-    implementation(project(":remote-robot"))
 }
 
 val sourcesJar by tasks.creating(Jar::class) {

--- a/remote-robot/build.gradle.kts
+++ b/remote-robot/build.gradle.kts
@@ -1,7 +1,12 @@
 plugins {
-    id("org.jetbrains.intellij")
+    id("org.jetbrains.intellij.platform")
 }
 
+repositories {
+    intellijPlatform {
+        defaultRepositories()
+    }
+}
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
@@ -12,6 +17,10 @@ dependencies {
 
     implementation("com.squareup.retrofit2:retrofit:2.11.0")
     implementation("com.squareup.retrofit2:converter-gson:2.11.0")
+
+    intellijPlatform {
+        intellijIdeaCommunity("2024.1")
+    }
 }
 
 // Create sources Jar from main kotlin sources
@@ -20,10 +29,6 @@ val sourcesJar by tasks.creating(Jar::class) {
     description = "Assembles sources JAR"
     archiveClassifier.set("sources")
     from(sourceSets.main.get().allSource)
-}
-
-intellij {
-    version.set("LATEST-EAP-SNAPSHOT")
 }
 
 publishing {

--- a/robot-server-core/build.gradle.kts
+++ b/robot-server-core/build.gradle.kts
@@ -1,11 +1,15 @@
 version = rootProject.ext["publish_version"] as String
 
 plugins {
-    id("org.jetbrains.intellij")
+    id("org.jetbrains.intellij.platform")
 }
 
 repositories {
     maven("https://repo.labs.intellij.net/intellij")
+
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 
@@ -19,6 +23,10 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.0")
+
+    intellijPlatform {
+        intellijIdeaCommunity("2024.1")
+    }
 }
 
 // Create sources Jar from main kotlin sources
@@ -29,9 +37,12 @@ val sourcesJar by tasks.creating(Jar::class) {
     from(sourceSets.main.get().allSource)
 }
 
-intellij {
-    updateSinceUntilBuild.set(false)
-    version.set("LATEST-EAP-SNAPSHOT")
+intellijPlatform {
+    pluginConfiguration {
+        ideaVersion {
+            untilBuild = provider { null }
+        }
+    }
 }
 
 publishing {

--- a/robot-server-plugin/build.gradle.kts
+++ b/robot-server-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.intellij")
+    id("org.jetbrains.intellij.platform")
 }
 val robotServerVersion = if (System.getenv("SNAPSHOT") == null) {
     rootProject.ext["publish_version"] as String
@@ -10,6 +10,9 @@ version = robotServerVersion
 
 repositories {
     maven("https://repo.labs.intellij.net/intellij")
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 configurations.runtimeClasspath {
@@ -30,6 +33,18 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.0")
+
+    intellijPlatform {
+        intellijIdeaCommunity("2024.1")
+    }
+}
+
+intellijPlatform {
+    pluginConfiguration {
+        ideaVersion {
+            untilBuild = provider { null }
+        }
+    }
 }
 
 // Create sources Jar from main kotlin sources
@@ -38,11 +53,6 @@ val sourcesJar by tasks.creating(Jar::class) {
     description = "Assembles sources JAR"
     archiveClassifier.set("sources")
     from(sourceSets.main.get().allSource)
-}
-
-intellij {
-    updateSinceUntilBuild.set(false)
-    version.set("LATEST-EAP-SNAPSHOT")
 }
 
 tasks {

--- a/test-recorder/build.gradle.kts
+++ b/test-recorder/build.gradle.kts
@@ -1,17 +1,25 @@
 version = rootProject.ext["publish_version"] as String
 
 plugins {
-    id("org.jetbrains.intellij")
+    id("org.jetbrains.intellij.platform")
 }
 
 repositories {
     maven("https://repo.labs.intellij.net/intellij")
+
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 
 dependencies {
     api(project(":robot-server-core"))
     api(project(":remote-fixtures"))
+
+    intellijPlatform {
+        intellijIdeaCommunity("2024.1")
+    }
 }
 
 // Create sources Jar from main kotlin sources
@@ -22,9 +30,12 @@ val sourcesJar by tasks.creating(Jar::class) {
     from(sourceSets.main.get().allSource)
 }
 
-intellij {
-    updateSinceUntilBuild.set(false)
-    version.set("2022.3")
+intellijPlatform {
+    pluginConfiguration {
+        ideaVersion {
+            untilBuild = provider { null }
+        }
+    }
 }
 
 publishing {

--- a/ui-test-example/build.gradle
+++ b/ui-test-example/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 }
 plugins {
-    id 'org.jetbrains.intellij'
+    id("org.jetbrains.intellij.platform")
     id 'org.jetbrains.kotlin.jvm'
     id 'java'
 }
@@ -12,6 +12,10 @@ plugins {
 repositories {
     mavenCentral()
     maven { url = "https://packages.jetbrains.team/maven/p/ij/intellij-dependencies" }
+
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 
@@ -34,34 +38,33 @@ dependencies {
 
     // Video Recording
     implementation 'com.automation-remarks:video-recorder-junit5:2.0'
+
+    intellijPlatform {
+        intellijIdeaCommunity("2024.1")
+    }
 }
 
-
-intellij {
-    version.set('LATEST-EAP-SNAPSHOT')
-}
-
-downloadRobotServerPlugin {
-    version.set(remoteRobotVersion)
-}
-
-
-runIdeForUiTests {
-//    In case your Idea is launched on remote machine you can enable public port and enable encryption of JS calls
-//    systemProperty "robot-server.host.public", "true"
-//    systemProperty "robot.encryption.enabled", "true"
-//    systemProperty "robot.encryption.password", "my super secret"
-
-    systemProperty "robot-server.port", "8082"
-    systemProperty "ide.mac.message.dialogs.as.sheets", "false"
-    systemProperty "jb.privacy.policy.text", "<!--999.999-->"
-    systemProperty "jb.consents.confirmation.enabled", "false"
-    systemProperty "ide.mac.file.chooser.native", "false"
-    systemProperty "jbScreenMenuBar.enabled", "false"
-    systemProperty "apple.laf.useScreenMenuBar", "false"
-    systemProperty "idea.trust.all.projects", "true"
-    systemProperty "ide.show.tips.on.startup.default.value", "false"
-//    systemProperty "eap.require.license", "true"
+intellijPlatformTesting.runIde {
+    runIdeForUiTests {
+        task {
+            jvmArgumentProviders.add({
+                [
+                        "-Drobot-server.port=8082",
+                        "-Dide.mac.message.dialogs.as.sheets=false",
+                        "-Djb.privacy.policy.text=<!--999.999-->",
+                        "-Djb.consents.confirmation.enabled=false",
+                        "-Dide.mac.file.chooser.native=false",
+                        "-DjbScreenMenuBar.enabled=false",
+                        "-Dapple.laf.useScreenMenuBar=false",
+                        "-Didea.trust.all.projects=true",
+                        "-Dide.show.tips.on.startup.default.value=false",
+                ]
+            } as CommandLineArgumentProvider)
+        }
+        plugins {
+            robotServerPlugin(remoteRobotVersion)
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
Originally it was assumed that execution on EDT provides readlock, but since 2025.1 this
is no longer the case, so plugin should emulate behavior by itself. This requires SDK update to
2024.1 at least that introduces WriteIntentReadAction. The more recent version is not used
because internally plugin should be compatible with the 4 latest releases, so we have to 
have 2024.1 here.